### PR TITLE
Add layer caching

### DIFF
--- a/neuro_extras/main.py
+++ b/neuro_extras/main.py
@@ -93,7 +93,9 @@ class ImageBuilder:
         image_ref: str,
         build_args: Sequence[str] = (),
     ) -> neuro_api.Container:
-        command = f"--dockerfile={dockerfile_path} --destination={image_ref}"
+        command = (
+            f"--dockerfile={dockerfile_path} --destination={image_ref} --cache=true"
+        )
         if build_args:
             command += "".join([f" --build-arg {arg}" for arg in build_args])
         return neuro_api.Container(

--- a/neuro_extras/main.py
+++ b/neuro_extras/main.py
@@ -84,7 +84,7 @@ class ImageBuilder:
 
         await self._client.storage.create(uri, _gen())
 
-    def _create_builder_container(
+    async def _create_builder_container(
         self,
         *,
         docker_config_uri: URL,
@@ -93,9 +93,19 @@ class ImageBuilder:
         image_ref: str,
         build_args: Sequence[str] = (),
     ) -> neuro_api.Container:
-        command = (
-            f"--dockerfile={dockerfile_path} --destination={image_ref} --cache=true"
-        )
+
+        async with neuro_api.get() as client:
+            registry_url_no_https = str(client.config.registry_url).replace(
+                "https://", ""
+            )
+            cache_repo = (
+                f"{registry_url_no_https}/{client.config.username}/layer-cache/cache"
+            )
+            command = (
+                f"--dockerfile={dockerfile_path} --destination={image_ref} "
+                f"--cache=true --cache-repo={cache_repo}"
+            )
+
         if build_args:
             command += "".join([f" --build-arg {arg}" for arg in build_args])
         return neuro_api.Container(
@@ -143,7 +153,7 @@ class ImageBuilder:
 
         logger.info(f"Submitting a builder job")
         image_ref = self.parse_image_ref(image_uri_str)
-        builder_container = self._create_builder_container(
+        builder_container = await self._create_builder_container(
             docker_config_uri=docker_config_uri,
             context_uri=context_uri,
             dockerfile_path=dockerfile_path,

--- a/tests/e2e/test_main.py
+++ b/tests/e2e/test_main.py
@@ -158,16 +158,16 @@ def test_image_build_custom_build_args(cli_runner: CLIRunner) -> None:
             "-f",
             str(dockerfile_path),
             "--build-arg",
-            "TEST_ARG=find_me",
+            f"TEST_ARG=arg-{tag}",
             "--build-arg",
-            "ANOTHER_TEST_ARG=metoo",
+            f"ANOTHER_TEST_ARG=arg-another-{tag}",
             ".",
             img_uri_str,
         ]
     )
     assert result.returncode == 0, result
-    assert "find_me" in result.stdout
-    assert "metoo" in result.stdout
+    assert f"arg-{tag}" in result.stdout
+    assert f"arg-another-{tag}" in result.stdout
 
 
 def test_seldon_deploy_from_local(cli_runner: CLIRunner) -> None:


### PR DESCRIPTION
Closes #13

Trivially adding layer caching for kaniko.

As discussed with @dalazx we're not going to use base image caching with kaniko due to unnecessary complexity required.

Tested manually via modifying a unit test:

- Building an image from a Dockerfile + another image from a similar Docker file with a new command 2 times in a row without caching: 15 minutes
- Same thing with caching enabled: 3.5 minutes.