### PR TITLE
[kaniko] increase image build timeout to 4 hrs

### DIFF
--- a/neuro_extras/main.py
+++ b/neuro_extras/main.py
@@ -172,7 +172,7 @@ class ImageBuilder:
             build_args=build_args,
         )
         # TODO: set proper tags
-        job = await self._client.jobs.run(builder_container, life_span=60 * 60)
+        job = await self._client.jobs.run(builder_container, life_span=4 * 60 * 60)
         logger.info(f"The builder job ID: {job.id}")
         return job
 


### PR DESCRIPTION
The image creation process sometimes may exceed specified boundaries of 1 hour.

Especially it may happen under specific circumstances such as slow I/O within a cluster (I personally faced such issue with `onprem-poc` cluster).

We discussed this problem with @mariyadavydova and decided to increase the image build job lifes-span from 1h to 4hrs, rejecting the alternative of exposing an additional parameter for `neuro-extras build` command.

cc @mariyadavydova 