### PR TITLE
Add command `neuro-extras flow init-demo`

### DIFF
--- a/neuro_extras/main.py
+++ b/neuro_extras/main.py
@@ -727,7 +727,7 @@ async def _flow_init_demo(path: Union[str, Path]) -> None:
             if dst.exists():
                 existing.append(dst.absolute())
         if existing:
-            details = " ".join(map(str, existing))
+            details = " ".join(map(str, sorted(existing)))
             raise click.ClickException(f"Destination file(s) already exist: {details}")
 
         for src, dst in copy_map:

--- a/neuro_extras/main.py
+++ b/neuro_extras/main.py
@@ -678,7 +678,7 @@ def flow_init_demo(path: str) -> None:
 
 async def _clone_git_repo(repo_url: str, destination: Union[str, Path]) -> None:
     info = f"Cloning git repository {repo_url}"
-    click.echo(info + "...")
+    click.echo(info)
     subprocess = await asyncio.create_subprocess_exec(
         "git", "clone", repo_url, str(destination)
     )

--- a/neuro_extras/main.py
+++ b/neuro_extras/main.py
@@ -732,8 +732,8 @@ async def _flow_init_demo(path: Union[str, Path]) -> None:
             shutil.copy(str(src), str(dst))
 
         click.echo(
-            "WARNING: All files and directories except those specified in "
-            "'.dockerignore' or '.neuroignore' will be uploaded to Neu.ro storage."
+            "WARNING: The whole directory will be uploaded to Neu.ro storage. Please"
+            " specify files to ignore in '.dockerignore' or '.neuroignore'."
         )
 
         click.echo(

--- a/neuro_extras/main.py
+++ b/neuro_extras/main.py
@@ -743,5 +743,5 @@ async def _flow_init_demo(path: Union[str, Path]) -> None:
         click.echo(
             f"Successfully created {len(copy_map)} files in '{path.absolute()}':"
         )
-        for file_path in _collect_relative_files_recursively(path):
-            click.echo(f"  {file_path}")
+        for _, dst in copy_map:
+            click.echo(f"  {dst.absolute()}")

--- a/neuro_extras/main.py
+++ b/neuro_extras/main.py
@@ -687,7 +687,7 @@ async def _clone_git_repo(repo_url: str, destination: Union[str, Path]) -> None:
         raise click.ClickException(f"{info} failed!")
 
 
-def _list_files_relative(
+def _list_relative(
     path: Union[str, Path], *, exclude: Optional[Collection[str]] = None,
 ) -> Iterator[Path]:
     path = Path(path)
@@ -697,7 +697,7 @@ def _list_files_relative(
         yield p.relative_to(path)
 
 
-def _list_files_recursively_relative(path: Union[str, Path],) -> Iterator[Path]:
+def _list_relative_recursively(path: Union[str, Path],) -> Iterator[Path]:
     path = Path(path)
     if path.is_dir():
         for root, dirs, files in os.walk(path, topdown=True):
@@ -720,7 +720,7 @@ async def _flow_init_demo(path: Union[str, Path]) -> None:
 
         copy_map = []
         existing = []
-        for relative in _list_files_relative(temp, exclude={".git", "README.md"}):
+        for relative in _list_relative(temp, exclude={".git", "README.md"}):
             src = temp / relative
             dst = path / relative
             copy_map.append((src, dst))
@@ -749,6 +749,6 @@ async def _flow_init_demo(path: Union[str, Path]) -> None:
         display = []
         for _, dst in copy_map:
             display.append(dst)
-            display.extend((dst / sub for sub in _list_files_recursively_relative(dst)))
+            display.extend((dst / sub for sub in _list_relative_recursively(dst)))
         for p in display:
             click.echo(f"  {p.relative_to(path)}")

--- a/tests/e2e/test_main.py
+++ b/tests/e2e/test_main.py
@@ -588,7 +588,8 @@ def test_flow_init_demo_ok(project_dir: Path, cli_runner: CLIRunner) -> None:
     assert "WARNING: The whole directory will be uploaded" in out, out
     assert "Successfully created" in out, out
     for path in [
-        ".neuro",
+        ".neuro/Dockerfile",
+        ".neuro/live.yml",
         ".neuroignore",
         ".neuro.toml",
     ]:
@@ -628,5 +629,5 @@ def test_flow_init_demo_fail_already_exist(
     err = res.stderr
     assert (
         "Error: Destination file(s) already exist: "
-        f"{project_dir}/.neuro {project_dir}/.neuro.toml"
+        f"{project_dir}/.neuro/Dockerfile {project_dir}/.neuro.toml"
     ) in err, err


### PR DESCRIPTION
Idea: we decided to keep things simple.
- we put all data we want to copy into `.neuro/`
- neuro-extras will be dumb: do not ask anything, do not overwrite. Just print: file/drectory `.neuro/` exists, please delete it.

Related PR: https://github.com/neuromation/neuro-flow-demo/pull/1
