### PR TITLE
[Do not merge] Debug tests

### DIFF
--- a/tests/e2e/test_main.py
+++ b/tests/e2e/test_main.py
@@ -55,6 +55,9 @@ def cli_runner(capfd: CaptureFixture, project_dir: Path) -> CLIRunner:
         if cmd == "neuro":
             args = [
                 "--show-traceback",
+                "--trace",
+                "--hide-token",
+                "--verbose",
                 "--disable-pypi-version-check",
                 "--color=no",
             ] + args


### PR DESCRIPTION
Run tests with `neuro --trace --verbose` parameters to check what causes *401 - Unauthorized access* error.