### PR TITLE
Fix tests: flaky and not

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ format:
 	black neuro_extras tests setup.py
 
 test_e2e:
-	pytest -vv --maxfail=3 ${PYTEST_FLAGS} tests/e2e
+	pytest -vv --maxfail=3 ${PYTEST_FLAGS} tests/e2e -s -k test_image
 
 test: lint test_e2e
 

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ format:
 	black neuro_extras tests setup.py
 
 test_e2e:
-	pytest -vv --maxfail=3 ${PYTEST_FLAGS} tests/e2e -s -k test_image
+	pytest -vv --maxfail=3 ${PYTEST_FLAGS} tests/e2e
 
 test: lint test_e2e
 

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1,8 +1,9 @@
 import logging
 import uuid
 from dataclasses import dataclass
+from pathlib import Path
 from subprocess import CompletedProcess
-from typing import Callable, Iterator, List
+from typing import Callable, Iterator, List, Optional, Union
 
 import pytest
 
@@ -34,3 +35,12 @@ def temp_random_secret(cli_runner: CLIRunner) -> Iterator[Secret]:
         if r.returncode != 0:
             details = f"code {r.returncode}, stdout: `{r.stdout}`, stderr: `{r.stderr}`"
             logger.warning(f"Could not delete secret '{secret.name}', {details}")
+
+
+def gen_random_file(location: Union[str, Path], name: Optional[str] = None) -> Path:
+    location = Path(location)
+    location.mkdir(parents=True, exist_ok=True)
+    name = name or f"file-{uuid.uuid4().hex[:8]}.txt"
+    file = location / name
+    file.write_text(str(uuid.uuid4()))
+    return file

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1,0 +1,36 @@
+import logging
+import uuid
+from dataclasses import dataclass
+from subprocess import CompletedProcess
+from typing import Callable, Iterator, List
+
+import pytest
+
+
+CLIRunner = Callable[[List[str]], CompletedProcess]
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class Secret:
+    name: str
+    value: str
+
+
+def generate_random_secret(name_prefix: str = "secret") -> Secret:
+    return Secret(
+        name=f"{name_prefix}-{uuid.uuid4().hex[:8]}", value=str(uuid.uuid4()),
+    )
+
+
+@pytest.fixture
+def temp_random_secret(cli_runner: CLIRunner) -> Iterator[Secret]:
+    secret = generate_random_secret()
+    try:
+        yield secret
+    finally:
+        r = cli_runner(["neuro", "secret", "rm", secret.name])
+        if r.returncode != 0:
+            details = f"code {r.returncode}, stdout: `{r.stdout}`, stderr: `{r.stderr}`"
+            logger.warning(f"Could not delete secret '{secret.name}', {details}")

--- a/tests/e2e/test_main.py
+++ b/tests/e2e/test_main.py
@@ -230,14 +230,19 @@ def test_image_copy(cli_runner: CLIRunner) -> None:
     assert result.returncode == 0, result
     sleep(10)
 
-    result = cli_runner(["neuro", "image", "tags", "image:extras-e2e-image-copy"])
+    # WORKAROUND: Fixing 401 Not Authorized because of this problem:
+    # https://github.com/neuromation/platform-registry-api/issues/209
+    rnd = uuid.uuid4().hex[:6]
+    image = f"image:extras-e2e-image-copy-{rnd}"
+
+    result = cli_runner(["neuro", "image", "tags", image])
     assert result.returncode == 0, result
     assert tag in result.stdout
 
-    result = cli_runner(["neuro", "image-copy", img_uri_str, "image:extras-e2e-copy"])
+    result = cli_runner(["neuro", "image-copy", img_uri_str, image])
     assert result.returncode == 0, result
     sleep(10)
-    result = cli_runner(["neuro", "image", "tags", "image:extras-e2e-copy"])
+    result = cli_runner(["neuro", "image", "tags", image])
     assert result.returncode == 0, result
 
 
@@ -376,7 +381,11 @@ def test_seldon_deploy_from_local(cli_runner: CLIRunner) -> None:
 
     pkg_path = Path("pkg")
     tag = str(uuid.uuid4())
-    img_uri_str = f"image:extras-e2e-seldon-local:{tag}"
+    # WORKAROUND: Fixing 401 Not Authorized because of this problem:
+    # https://github.com/neuromation/platform-registry-api/issues/209
+    rnd = uuid.uuid4().hex[:6]
+    img_name = f"image:extras-e2e-seldon-local-{rnd}"
+    img_uri_str = f"{img_name}:{tag}"
     result = cli_runner(["neuro", "seldon-init-package", str(pkg_path)])
     assert result.returncode == 0, result
     assert "Copying a Seldon package scaffolding" in result.stdout, result
@@ -389,7 +398,7 @@ def test_seldon_deploy_from_local(cli_runner: CLIRunner) -> None:
     assert result.returncode == 0, result
     sleep(10)
 
-    result = cli_runner(["neuro", "image", "tags", "image:extras-e2e-seldon-local"])
+    result = cli_runner(["neuro", "image", "tags", img_name])
     assert result.returncode == 0, result
     assert tag in result.stdout
 

--- a/tests/e2e/test_main.py
+++ b/tests/e2e/test_main.py
@@ -355,8 +355,13 @@ def test_image_build_volume(cli_runner: CLIRunner) -> None:
             )
         )
 
+    # WORKAROUND: Fixing 401 Not Authorized because of this problem:
+    # https://github.com/neuromation/platform-registry-api/issues/209
+    rnd = uuid.uuid4().hex[:6]
+    image = f"image:extras-e2e-image-copy-{rnd}"
+
     tag = str(uuid.uuid4())
-    img_uri_str = f"image:extras-e2e:{tag}"
+    img_uri_str = f"{image}:{tag}"
 
     result = cli_runner(
         [

--- a/tests/e2e/test_main.py
+++ b/tests/e2e/test_main.py
@@ -121,7 +121,12 @@ def test_image_build_custom_dockerfile(cli_runner: CLIRunner) -> None:
         )
 
     tag = str(uuid.uuid4())
-    img_uri_str = f"image:extras-e2e-custom-dockerfile:{tag}"
+
+    # WORKAROUND: Fixing 401 Not Authorized because of this problem:
+    # https://github.com/neuromation/platform-registry-api/issues/209
+    rnd = uuid.uuid4().hex[:6]
+    img_name = f"image:extras-e2e-custom-dockerfile-{rnd}"
+    img_uri_str = f"{img_name}:{tag}"
 
     result = cli_runner(
         ["neuro", "image-build", "-f", str(dockerfile_path), ".", img_uri_str]
@@ -129,9 +134,7 @@ def test_image_build_custom_dockerfile(cli_runner: CLIRunner) -> None:
     assert result.returncode == 0, result
     sleep(10)
 
-    result = cli_runner(
-        ["neuro", "image", "tags", "image:extras-e2e-custom-dockerfile"]
-    )
+    result = cli_runner(["neuro", "image", "tags", img_name])
     assert result.returncode == 0, result
     assert tag in result.stdout
 

--- a/tests/e2e/test_main.py
+++ b/tests/e2e/test_main.py
@@ -27,11 +27,6 @@ from .conftest import CLIRunner, Secret, gen_random_file
 
 logger = logging.getLogger(__name__)
 
-# XXX: tiny random command to disable docker cache when used in Dockerfile
-DOCKERFILE_DISABLE_CACHE_CMD = (
-    'ADD "https://www.random.org/cgi-bin/randbyte?nbytes=10&format=h" skipcache'
-)
-
 
 @pytest.fixture
 def project_dir() -> Iterator[Path]:
@@ -120,7 +115,7 @@ def test_image_build_custom_dockerfile(cli_runner: CLIRunner) -> None:
             textwrap.dedent(
                 f"""\
                 FROM ubuntu:latest
-                ADD {random_file_to_disable_layer_caching} .
+                ADD {random_file_to_disable_layer_caching} /tmp
                 RUN echo !
                 """
             )
@@ -163,7 +158,7 @@ def test_ignored_files_are_not_copied(cli_runner: CLIRunner,) -> None:
         textwrap.dedent(
             f"""\
             FROM ubuntu:latest
-            ADD {random_file_to_disable_layer_caching}
+            ADD {random_file_to_disable_layer_caching} /tmp
             ADD {ignored_file} /
             RUN cat /{ignored_file}
             """
@@ -225,7 +220,7 @@ def test_image_copy(cli_runner: CLIRunner) -> None:
             textwrap.dedent(
                 f"""\
                 FROM alpine:latest
-                ADD {random_file_to_disable_layer_caching}
+                ADD {random_file_to_disable_layer_caching} /tmp
                 RUN echo !
                 """
             )
@@ -270,7 +265,7 @@ def test_image_build_custom_build_args(cli_runner: CLIRunner) -> None:
             textwrap.dedent(
                 f"""\
                 FROM ubuntu:latest
-                ADD {random_file_to_disable_layer_caching}
+                ADD {random_file_to_disable_layer_caching} /tmp
                 ARG TEST_ARG
                 ARG ANOTHER_TEST_ARG
                 RUN echo $TEST_ARG
@@ -320,7 +315,7 @@ def test_image_build_env(cli_runner: CLIRunner, temp_random_secret: Secret) -> N
             textwrap.dedent(
                 f"""\
                 FROM ubuntu:latest
-                ADD {random_file_to_disable_layer_caching}
+                ADD {random_file_to_disable_layer_caching} /tmp
                 ARG GIT_TOKEN
                 ENV GIT_TOKEN=$GIT_TOKEN
                 RUN echo git_token=$GIT_TOKEN
@@ -366,7 +361,7 @@ def test_image_build_volume(cli_runner: CLIRunner, temp_random_secret: Secret) -
             textwrap.dedent(
                 f"""\
                 FROM ubuntu:latest
-                ADD {random_file_to_disable_layer_caching}
+                ADD {random_file_to_disable_layer_caching} /tmp
                 ADD secret.txt /
                 RUN echo git_token=$(cat secret.txt)
                 """

--- a/tests/e2e/test_main.py
+++ b/tests/e2e/test_main.py
@@ -383,7 +383,7 @@ def test_image_build_volume(cli_runner: CLIRunner, temp_random_secret: Secret) -
             "-f",
             str(dockerfile_path),
             "-v",
-            "secret:gh-token-e2e:/workspace/secret.txt",
+            f"secret:{sec.name}:/workspace/secret.txt",
             ".",
             img_uri_str,
         ]

--- a/tests/e2e/test_main.py
+++ b/tests/e2e/test_main.py
@@ -221,19 +221,19 @@ def test_image_copy(cli_runner: CLIRunner) -> None:
             )
         )
 
+    # WORKAROUND: Fixing 401 Not Authorized because of this problem:
+    # https://github.com/neuromation/platform-registry-api/issues/209
+    rnd = uuid.uuid4().hex[:6]
+    image = f"image:extras-e2e-image-copy-{rnd}"
+
     tag = str(uuid.uuid4())
-    img_uri_str = f"image:extras-e2e-image-copy:{tag}"
+    img_uri_str = f"{image}:{tag}"
 
     result = cli_runner(
         ["neuro", "image-build", "-f", str(dockerfile_path), ".", img_uri_str]
     )
     assert result.returncode == 0, result
     sleep(10)
-
-    # WORKAROUND: Fixing 401 Not Authorized because of this problem:
-    # https://github.com/neuromation/platform-registry-api/issues/209
-    rnd = uuid.uuid4().hex[:6]
-    image = f"image:extras-e2e-image-copy-{rnd}"
 
     result = cli_runner(["neuro", "image", "tags", image])
     assert result.returncode == 0, result


### PR DESCRIPTION
Problems:
1. Workaround for https://github.com/neuromation/platform-registry-api/issues/209. Needed to make CI green to make a release.
2. Flaky: secret names were hard-coded, therefore parallel builds were conflicting
3. Flaky: sometimes `assert f"git_token={secret}" in result.stdout` didn't show up in stdout because this layer was cached and wasn't executed.

Thanks @YevheniiSemendiak and @mariyadavydova for helping debug the problem!