### PR TITLE
Add aws, rsync and gsutil to the build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,11 @@ FROM python:3.7-stretch as requirements
 
 ARG NEURO_EXTRAS_VERSION
 
+RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg  add - && apt-get update -y && apt-get install google-cloud-sdk -y
+RUN apt-get install rsync -y
 RUN pip install --user \
-    neuro-extras==$NEURO_EXTRAS_VERSION
-
+    neuro-extras==$NEURO_EXTRAS_VERSION \
+    awscli google-cloud-storage
 
 FROM python:3.7-stretch as service
 

--- a/neuro_extras/main.py
+++ b/neuro_extras/main.py
@@ -222,7 +222,7 @@ class DataCopier:
             args = f"-x {args}"
         return neuro_api.Container(
             image=neuro_api.RemoteImage.new_external_image("neuromation/neuro-extras"),
-            resources=neuro_api.Resources(cpu=4.0, memory_mb=4096),
+            resources=neuro_api.Resources(cpu=2.0, memory_mb=4096),
             volumes=[neuro_api.Volume(storage_uri, "/var/storage")],
             entrypoint=f"neuro-extras data cp {args}",
         )


### PR DESCRIPTION
Related to #38 and requires one more alpha release anyway.

CPU requirement changed from 4 to 2 in order to simplify testing on dev cluster. We're yet to see an unzip problem worth 4 CPUs :)