### PR TITLE
[Ingestion] Add dependencies for gsutil to copy large BLOBS from google storage.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,12 +6,12 @@ RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.c
 RUN apt-get install rsync -y
 RUN pip install --user \
     neuro-extras==$NEURO_EXTRAS_VERSION \
-    awscli google-cloud-storage
+    awscli google-cloud-storage crcmod
 
 FROM python:3.7-stretch as service
 
 RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg  add - && apt-get update -y && apt-get install google-cloud-sdk -y
-RUN apt-get install rsync -y
+RUN apt-get install rsync gcc python3-dev python3-setuptools -y
 
 COPY --from=requirements /root/.local /root/.local
 COPY docker.entrypoint.sh /var/lib/neuro/entrypoint.sh


### PR DESCRIPTION
If we don't do it - `neuro data cp` cann not perform an ingestion.

Note: it is actually needed to speedup CRC calculation. Otherwise, we need a hack to disable CRC, which is unsafe.