### PR TITLE
Rename temp directory .neuro-tmp -> .neuro-extras/tmp

### DIFF
--- a/neuro_extras/main.py
+++ b/neuro_extras/main.py
@@ -30,7 +30,7 @@ logger = logging.getLogger(__name__)
 
 ASSETS_PATH = Path(__file__).resolve().parent / "assets"
 SELDON_CUSTOM_PATH = ASSETS_PATH / "seldon.package"
-TEMP_UNPACK_DIR = Path.home() / ".neuro-tmp"
+TEMP_UNPACK_DIR = Path.home() / ".neuro-extras" / "tmp"
 
 
 @dataclass


### PR DESCRIPTION
Reason:
1. indeed, `neuro-extras` should not use `neuro`'s directory as they will inevitably interfere.
2. better if `neuro-extras` has its own directory `~/.neuro-extras`, which we can potentially re-use in future.

so it closes https://github.com/neuromation/neuro-extras/issues/73 indirectly.